### PR TITLE
Vector mean + testes atualizados

### DIFF
--- a/Projetos/E-Assembly/config_testes.txt
+++ b/Projetos/E-Assembly/config_testes.txt
@@ -30,15 +30,15 @@ LCDletraGrupo.nasm 0 10000
 ## conceito B
 ###########################
 
-#isEven.nasm 2 1000
-#palindromo.nasm 2 1000
-#LCDnomeGrupo.nasm 0 10000
+isEven.nasm 2 1000
+palindromo.nasm 2 1000
+LCDnomeGrupo.nasm 0 10000
 
 ###########################
 ## conceito A
 ###########################
 
-#vectorMean.nasm 2 2000
+vectorMean.nasm 2 2000
 #SWeLED2.nasm 1 1000
 
 

--- a/Projetos/E-Assembly/src/vectorMean.nasm
+++ b/Projetos/E-Assembly/src/vectorMean.nasm
@@ -19,3 +19,58 @@
 ; RAM[7]:  1  | RAM[7]:  1 |
 ; RAM[8]:  4  | RAM[8]:  4 -
 ; ------------------------------------
+
+
+; R4 --> monitora posicao
+; R3 --> monitora qtas vezes rodar
+; R2 --> guarda o valor original de R4
+
+leaw $R4,%A
+movw (%A), %D
+movw %A, (%A)
+leaw $R2, %A
+movw %D, (%A)
+leaw $R3, %A
+movw %D, (%A)
+
+LOOP:
+leaw $R1, %A
+movw (%A), %D
+leaw $R4, %A
+movw (%A), %A
+incw %A
+addw (%A), %D, %D
+leaw $R1, %A
+movw %D, (%A)
+leaw $R4, %A
+movw (%A), %D
+incw %D
+movw %D, (%A)
+leaw $R3, %A
+movw (%A), %D
+decw %D
+movw %D, (%A)
+leaw $LOOP, %A
+jg %D
+nop
+
+DIV:
+
+leaw $R1, %A
+movw (%A), %D ;Salva R1 em D
+leaw $R2, %A 
+rsubw %D, (%A), %D ;Subtrai R1 de R0
+movw %D, (%A) ; Salva novo valor de R0
+leaw $END, %A
+
+jl %D ; Pula para o fim se R0 for menor que 0
+nop
+
+leaw $R0, %A
+addw (%A), $1, %D 
+movw %D, (%A)     ; incrementa R2
+leaw $DIV, %A 
+jmp              ; Repete
+nop
+
+END:


### PR DESCRIPTION
#98 

OBS: O teste 1 apresenta o tamanho do vetor em RAM[3], o que vai contra ao enunciado e ao teste 0. 
Adotamos o enunciado como base, portanto espera-se que o teste 0 irá falhar. 